### PR TITLE
Fix SCAP-Security-Guide URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
           <div class="col-md-4">
           <h3>SCAP SECURITY GUIDE (SSG)</h3>
           <p>Delivers security guidance, baselines, and associated validation mechanisms using the Security Content Automation Protocol (SCAP) for hardening Red Hat products.<br></p>
-          <a class="btn btn-primary" href="https://fedorahosted.org/scap-security-guide" target="_blank" role="button">View Repo Page</a> <!-- <a class="learn-more" target="_blank" href="#">Learn More <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></a> -->
+          <a class="btn btn-primary" href="https://github.com/openscap/scap-security-guide" target="_blank" role="button">View Repo Page</a> <!-- <a class="learn-more" target="_blank" href="#">Learn More <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></a> -->
           </div>
           <div class="col-md-4">
             <h3>SECURE HOST BASELINE (SHB)</h3>

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
           <div class="col-md-4">
           <h3>SCAP SECURITY GUIDE (SSG)</h3>
           <p>Delivers security guidance, baselines, and associated validation mechanisms using the Security Content Automation Protocol (SCAP) for hardening Red Hat products.<br></p>
-          <a class="btn btn-primary" href="https://github.com/openscap/scap-security-guide" target="_blank" role="button">View Repo Page</a> <!-- <a class="learn-more" target="_blank" href="#">Learn More <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></a> -->
+          <a class="btn btn-primary" href="https://github.com/complianceascode/content" target="_blank" role="button">View Repo Page</a> <!-- <a class="learn-more" target="_blank" href="#">Learn More <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></a> -->
           </div>
           <div class="col-md-4">
             <h3>SECURE HOST BASELINE (SHB)</h3>


### PR DESCRIPTION
- fedorahosted.org has been retired and no longer exists. PR fixes the SCAP-Security-Guide URL.