### PR TITLE
Removed banner from OSCON

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: Open Source @ NSA
 description: THE FOLLOWING OPEN SOURCE SOFTWARE was developed within the National Security Agency and is now available to the public.
-notification_banner: true
+notification_banner: false
 notification_message: NSA is back at OSCON! Stop by our booth for info on ghidra, open source, and careers!
 
 # GitHub information


### PR DESCRIPTION
This banner can easily be enabled again another date, but has been hidden for now. Example can be seen here: https://swysocki-gliacell.github.io/nationalsecurityagency.github.io/