### PR TITLE
Update links to use www.nsa.gov

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -59,7 +59,7 @@ contact:
       external: true
       type: youtube
     - text: RSS Feed
-      href: https://nsa.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=920&max=20
+      href: https://www.nsa.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=920&max=20
       external: true
       type: rss
   heading: NSA Technology Transfer Program

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -20,7 +20,7 @@ secondary:
     href: https://github.com/nsacyber
     external: true
   - text: Tech Transfer Program
-    href: https://nsa.gov/what-we-do/research/technology-transfer/
+    href: https://www.nsa.gov/what-we-do/research/technology-transfer/
     external: true
 
 docs:
@@ -42,13 +42,13 @@ docs:
 
 footer:
   - text: Terms of Use
-    href: https://nsa.gov/terms-of-use/#terms
+    href: https://www.nsa.gov/terms-of-use/#terms
     external: true
   - text: Web Privacy & Security
-    href: https://nsa.gov/terms-of-use/#privacy
+    href: https://www.nsa.gov/terms-of-use/#privacy
     external: true
   - text: NSA.gov
-    href: https://NSA.gov
+    href: https://www.nsa.gov
     external: true
   - text: CODE.gov
     href: https://code.gov


### PR DESCRIPTION
Avoid unnecessary redirects to www.nsa.gov by going there directly,
instead of through nsa.gov (without the www.)