### PR TITLE
chore: use new setup-ruby library for workflow

### DIFF
--- a/.github/workflows/jekyll.yaml
+++ b/.github/workflows/jekyll.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
     - name: Cache gems


### PR DESCRIPTION
The current CI workflow was failing because the dependency is deprecated and no longer maintained.